### PR TITLE
bunch of cli improvements, file format val only

### DIFF
--- a/kv/cmd/clear.go
+++ b/kv/cmd/clear.go
@@ -21,9 +21,8 @@ namespaces as well. `,
 	Run: func(cmd *cobra.Command, args []string) {
 		ns, _ := cmd.Flags().GetString("namespace")
 		silent, _ := cmd.Flags().GetBool("silent")
-
 		lookup_path := util.GetLookupPath(ns, "")
-		util.Vprint(lookup_path)
+		util.Vprint("Clearing: ", lookup_path)
 		err := os.RemoveAll(lookup_path)
 		if err != nil && !silent {
 			log.Fatal(err)

--- a/kv/cmd/dirname.go
+++ b/kv/cmd/dirname.go
@@ -1,0 +1,53 @@
+/*
+Copyright © 2019 MICHAEL McDERMOTT
+
+*/
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/xkortex/xac/kv/util"
+)
+
+// dirnameCmd represents the dirname command
+var pathCmd = &cobra.Command{
+	Use:   "path",
+	Aliases: []string{"p"},
+
+	Short: "Get the directory name of the kv store",
+	Long: `Returns the dirname of the kv store or a namespace root dir.
+If no key is given, the dirname of the kv store is returned. 
+If a key is given, the path to the keyfile is returned. 
+It is based on AppDirs UserDataDir. In Linux, this is $XDG_DATA_HOME`,
+	Run: func(cmd *cobra.Command, args []string) {
+		key := ""
+		if len(args) == 1 {
+			key = args[0]
+		} else if len(args) > 1 {
+			panic("/\\--/\\ Must have at most one argument (handling under construction)")
+		}
+		ns, _ := cmd.Flags().GetString("namespace")
+
+		lookup_path := util.GetLookupPath(ns, key)
+		fmt.Println(lookup_path)
+
+	},
+}
+
+var appdirCmd = &cobra.Command{
+	Use:   "appdir",
+	Short: "Get the base application directory name of the kv store",
+	Long: `Returns the dirname where the kv store is rooted. 
+It is based on AppDirs UserDataDir. In Linux, this is $XDG_DATA_HOME`,
+	Run: func(cmd *cobra.Command, args []string) {
+		lookup_path := util.GetLookupPath("", "")
+		fmt.Println(lookup_path)
+
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(pathCmd)
+	RootCmd.AddCommand(appdirCmd)
+}

--- a/kv/cmd/get.go
+++ b/kv/cmd/get.go
@@ -14,6 +14,8 @@ import (
 // getCmd represents the get command
 var getCmd = &cobra.Command{
 	Use:   "get",
+	Aliases: []string{"g"},
+
 	Short: "Get a value from the store",
 	Long: `Attempts to get a value from the store given the provided key`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -30,6 +32,8 @@ var getCmd = &cobra.Command{
 		if err != nil && !silent {
 			log.Fatal(err)
 		}
+		// So bash is smart enough to strip whitespace so even though this adds
+		// a newline, it still seems to work for loading and
 		fmt.Println(val)
 	},
 }

--- a/kv/cmd/ls.go
+++ b/kv/cmd/ls.go
@@ -12,6 +12,8 @@ import (
 // lsCmd represents the ls command
 var lsCmd = &cobra.Command{
 	Use:   "ls",
+	Aliases: []string{"l", "list"},
+
 	Short: "List values",
 	Long: `List values present in the store`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/kv/cmd/rm.go
+++ b/kv/cmd/rm.go
@@ -14,6 +14,8 @@ import (
 // rmCmd represents the rm command
 var rmCmd = &cobra.Command{
 	Use:   "rm",
+	Aliases: []string{"del", "dlt"},
+
 	Short: "Remove a key from the store",
 	Long: `Deletes the key from the kv store`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/kv/cmd/root.go
+++ b/kv/cmd/root.go
@@ -11,21 +11,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var developer string
+
 // RootCmd represents the root command
 var RootCmd = &cobra.Command{
 	Use:   "kv",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Utility for getting and setting key-value pairs",
+	Long: `Does what it says on the tin. Bare-bone, no-nonsense kv store. 
+Keys are stored as paths. 
+Examples:
+    $ kv foo=bar                  # Set foo to bar
+    $ echo spam | kv foo          # set foo to spam
+    $ kv foo                      # Get value of foo
+    spam`,
 	Run: func(cmd *cobra.Command, args []string) {
 		util.Vprint("root called")
 		util.Vprint(args)
 		ns, _ := cmd.PersistentFlags().GetString("namespace")
 		util.Vprint(ns)
+		//if err := cmd.Usage(); err != nil {
+		//	log.Fatalf("Error executing root command: %v", err)
+		//}
+		log.Fatal(cmd.SilenceErrors, cmd.SilenceUsage)
+
 	},
 }
 
@@ -38,6 +46,8 @@ func Execute() {
 }
 
 func init() {
+	cobra.OnInitialize(initConfig)
+
 	//RootCmd.AddCommand(RootCmd)
 
 	// Here you will define your flags and configuration settings.
@@ -52,4 +62,10 @@ func init() {
 	RootCmd.PersistentFlags().BoolP("silent", "s", false, "Suppress errors")
 	RootCmd.PersistentFlags().BoolP("stdin", "-", false, "Read from standard in")
 	RootCmd.Flags().BoolP("verbose", "v", false, "Verbose tracing (in progress)")
+	RootCmd.PersistentFlags().StringVar(&developer, "developer", "Unknown Developer!", "Developer name.")
+
+}
+
+func initConfig() {
+// todo: use init config to do stuff based on env
 }

--- a/kv/cmd/set.go
+++ b/kv/cmd/set.go
@@ -14,7 +14,9 @@ import (
 // setCmd represents the set command
 var setCmd = &cobra.Command{
 	Use:   "set",
-	Short: "A brief description of your command",
+	Aliases: []string{"s"},
+
+	Short: "Set a key to a value",
 	Long: `Set a key to a value according to either command line input or 
 standard in`,
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
bunch of cli improvements 
- ls formatting for namespaces 
- changed files to store raw value instead of key=val
- url escaping key names for paths in case keys have goofy characters
- still have some issues with keys that look like namespaces (should these auto namespace?) and ls formatting 